### PR TITLE
Removed standard library packages

### DIFF
--- a/EnigmaCracker/requirements.txt
+++ b/EnigmaCracker/requirements.txt
@@ -1,9 +1,3 @@
-os
 requests
 bip_utils
-sys
-subprocess
-logging
 python-dotenv
-platform
-time


### PR DESCRIPTION
Packages os, sys, subprocess, logging, platform, and time are part of the standard library and come pre-installed with Python. They don't need to be included in requirements.txt.